### PR TITLE
Change compose.sim.gazebo.yaml with actual docker compose version

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,14 @@ docker compose -f compose.rosbot.yaml up
 > **Prerequisites**
 >
 > The `compose.sim.gazebo.yaml` file uses NVIDIA Container Runtime. Make sure you have NVIDIA GPU and the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) installed.
-
+> This project has been tested on the following setup:
+> ```bash
+>$ docker compose version
+>Docker Compose version 2.17.0
+>$ docker --version
+>Docker version 23.0.1, build a5ee5b1dfc
+>```
+> Additionally, the `compose.sim.gazebo.yaml` file in this project uses NVIDIA Container Runtime. So, please make sure that you have an NVIDIA GPU and the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) installed on your system before moving forward.
 Start the containers in a new terminal:
 
 ```bash

--- a/compose.sim.gazebo.yaml
+++ b/compose.sim.gazebo.yaml
@@ -2,7 +2,13 @@ services:
 
   rviz:
     image: husarion/rviz2:galactic-8.5.2-20230204-stable
-    runtime: nvidia
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
     container_name: rviz
     network_mode: host
     ipc: host
@@ -17,7 +23,13 @@ services:
 
   rosbot-xl:
     image: husarion/rosbot-xl-gazebo:humble-0.3.0-20230204
-    runtime: nvidia
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
     network_mode: host


### PR DESCRIPTION
The `compose.sim.gazebo.yaml` use an old version of docker and docker compose.
This project has been tested on the following setup:
```bash
$ docker compose version
Docker Compose version 2.17.0
$ docker --version
Docker version 23.0.1, build a5ee5b1dfc
```

I change  the lines with
```yaml
    runtime: nvidia
```
with
```yaml
    deploy:
      resources:
        reservations:
          devices:
            - driver: nvidia
              count: 1
              capabilities: [gpu]
    container_name: rviz
    network_mode: host
```